### PR TITLE
Temporarily force v2.8.1 (and some unrelated cleanup)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && mkdir -p /usr/share/desktop-directories \
     # Install Firefox without Snap.
     && add-apt-repository ppa:mozillateam/ppa \
-    && apt update \
-    && apt install -y firefox-esr --no-install-recommends \
+    && apt-get update \
+    && apt-get install -y firefox-esr --no-install-recommends \
     # Clean everything up.
-    && apt autoclean -y \
-    && apt autoremove -y \
+    && apt-get autoclean -y \
+    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install VirtualGL and TurboVNC
@@ -35,7 +35,7 @@ RUN wget -qO /tmp/virtualgl_${VIRTUALGL_VERSION}_amd64.deb https://packagecloud.
     && dpkg -i /tmp/turbovnc_${TURBOVNC_VERSION}_amd64.deb \
     && rm -rf /tmp/*.deb
 
-# Install Prusaslicer.
+# Install PrusaSlicer.
 WORKDIR /slic3r
 ADD get_latest_prusaslicer_release.sh /slic3r
 RUN chmod +x /slic3r/get_latest_prusaslicer_release.sh \
@@ -55,7 +55,7 @@ RUN chmod +x /slic3r/get_latest_prusaslicer_release.sh \
   && mkdir -p /prints/ \
   && chown -R slic3r:slic3r /slic3r/ /home/slic3r/ /prints/ /configs/ \
   && locale-gen en_US \
-  && mkdir /configs/.local \
+  && mkdir -p /configs/.local \
   && mkdir -p /configs/.config/ \
   && ln -s /configs/.config/ /home/slic3r/ \
   && mkdir -p /home/slic3r/.config/ \

--- a/get_latest_prusaslicer_release.sh
+++ b/get_latest_prusaslicer_release.sh
@@ -2,7 +2,7 @@
 
 TMPDIR="$(mktemp -d)"
 
-curl -SsL https://api.github.com/repos/prusa3d/PrusaSlicer/releases/latest > $TMPDIR/latest.json
+curl -SsL https://api.github.com/repos/prusa3d/PrusaSlicer/releases/tags/version_2.8.1 > $TMPDIR/latest.json
 
 # Grabs the first item of the latest result of the AppImage.
 url=$(jq -r '.assets[] | select(.browser_download_url|test("linux-x64-older-distros-GTK3.*AppImage$"))|.browser_download_url' $TMPDIR/latest.json)


### PR DESCRIPTION
PrusaSlicer 2.9.0 dropped support for AppImage, and the "replacement" Flatpak builds are not compatible with Docker (and probably wouldn't support VirtualGL without lots of hacking even if you got past the Docker issues).  I suspect the best way forward would be to convert this to a two-stage docker build, where the first stage compiles the latest PrusaSlicer from source (in an Ubuntu container), then the second stage builds the runtime image with the compiled copy of PrusaSlicer.  However, that isn't a trivial project.

For now, I simply hard-coded v2.8.1, so that the AppImage-based container can continue to be built for v2.8.1

I also cleaned up a few commands to eliminate some warnings when building.